### PR TITLE
feat: GH Action sync OpenCraft fork with upstream

### DIFF
--- a/.github/workflows/sync-opencraft-forks-with-upstream.yml
+++ b/.github/workflows/sync-opencraft-forks-with-upstream.yml
@@ -1,0 +1,80 @@
+name: Sync OpenCraft Forks with upstream
+
+# Controls when the workflow will run
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # Runs every Monday 00:00 UTC
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  sync:
+    strategy:
+      matrix:
+        include:
+          # The fork repo provided needs to be in the {owner}/{repo} format
+          - fork_repo: open-craft/edx-platform
+            fork_branch: opencraft-release/palm.1
+            upstream_repo: https://github.com/openedx/edx-platform
+            upstream_branch: open-release/palm.master
+
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
+
+    steps:
+      - name: Get and store current datetime stamp
+        id: current-datetime-stamp
+        run: echo "DATE_TIME_STAMP=$(date +'%Y%m%d-%s')" >> "$GITHUB_OUTPUT"
+
+      - name: Construct and store sync branch name
+        id: sync-branch
+        run: echo "SYNC_BRANCH=sync-${{ matrix.upstream_branch }}-${{ steps.current-datetime-stamp.outputs.DATE_TIME_STAMP }}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git to use GitHub CLI for credentials
+        run: gh auth setup-git -h github.com
+
+      - name: Checkout Forked Repo
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ matrix.fork_repo }}
+          token: ${{ env.GITHUB_TOKEN }}
+
+      - name: Add Remote Upstream
+        run: git remote add upstream ${{ matrix.upstream_repo }}
+
+      - name: Fetch Latest from Upstream
+        run: git fetch upstream
+
+      - name: Create a new branch off Upstream master
+        run: git checkout -b ${{ steps.sync-branch.outputs.SYNC_BRANCH }} upstream/${{ matrix.upstream_branch }}
+
+      - name: Push new branch to Fork
+        run: git push origin
+
+      - name: Create PR on Fork with latest changes (if any) from Upstream
+        run: >
+          gh pr create
+          --repo ${{ matrix.fork_repo }}
+          --base ${{ matrix.fork_branch }}
+          --head $(git branch --show-current)
+          --title "Sync ${{ matrix.fork_branch }} with Upstream ${{ steps.current-datetime-stamp.outputs.DATE_TIME_STAMP }}"
+          --body '
+          Syncing ${{ matrix.fork_branch }} with Upstream
+
+          ## Note on Conflicts ⚠️
+
+          In cases of conflicts you can go ahead and resolve it here on Github if it is simple enough.
+          However if it is a more complicated conflict please follow the steps below:
+
+            1. Check out `${{ steps.sync-branch.outputs.SYNC_BRANCH }}` locally:
+            2. Pull latest changes from `${{ matrix.fork_branch }}` into that branch, make sure your `[REMOTE]` is pointing to `${{ matrix.fork_branch }}`:
+            ```sh
+            git pull [REMOTE] ${{ matrix.fork_branch }}
+            ```
+            3. Resolve the conflicts locally, then commit the result. This will create a new merge commit.
+            4. Push the new merge commit to `${{ steps.sync-branch.outputs.SYNC_BRANCH }}` to update this PR
+            5. Review the PR again and merge when ready!
+            **Note: Please use the "Create a merge commit" option as it avoids issues when checking diffs with upstream.**' ||
+            (echo "No changes detected. Deleting sync branch..." && git push origin --delete ${{ steps.sync-branch.outputs.SYNC_BRANCH }})


### PR DESCRIPTION
Add a GH Action Workflow to automate creating PRs to review and sync changes from upstream. Starting with the `opencraft-release/palm.1` branch.

Internal-ref: https://tasks.opencraft.com/browse/BB-7656