### PR TITLE
feat: add Quince branch of edx-platform

### DIFF
--- a/.github/workflows/sync-opencraft-forks-with-upstream.yml
+++ b/.github/workflows/sync-opencraft-forks-with-upstream.yml
@@ -22,6 +22,18 @@ jobs:
             fork_branch: opencraft-release/quince.1
             upstream_repo: openedx/edx-platform
             upstream_branch: open-release/quince.master
+          - fork_repo: open-craft/frontend-app-learning
+            fork_branch: opencraft-release/quince.1
+            upstream_repo: openedx/frontend-app-learning
+            upstream_branch: open-release/quince.master
+          - fork_repo: open-craft/frontend-app-gradebook
+            fork_branch: opencraft-release/quince.1
+            upstream_repo: openedx/frontend-app-gradebook
+            upstream_branch: open-release/quince.master
+          - fork_repo: open-craft/frontend-app-authn
+            fork_branch: opencraft-release/quince.1
+            upstream_repo: openedx/frontend-app-authn
+            upstream_branch: open-release/quince.master
 
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/sync-opencraft-forks-with-upstream.yml
+++ b/.github/workflows/sync-opencraft-forks-with-upstream.yml
@@ -18,6 +18,10 @@ jobs:
             fork_branch: opencraft-release/palm.1
             upstream_repo: openedx/edx-platform
             upstream_branch: open-release/palm.master
+          - fork_repo: open-craft/edx-platform
+            fork_branch: opencraft-release/quince.1
+            upstream_repo: openedx/edx-platform
+            upstream_branch: open-release/quince.master
 
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
This adds automatic syncing of our `opencraft-release/quince.1` branch with the upstream `open-release/quince.master`.